### PR TITLE
Release 0.2.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.11b1
+    rev: 21.12b0
     hooks:
       - id: black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2022-01-26
+### Fixed
+- `datetime`, `time` and `date` instances are now represented following [ISO-8601](https://www.iso.org/iso-8601-date-and-time-format.html) format instead of raising a `TypeError`.
+- Default to the `str` representation of value instead of raising a `TypeError` for non-standard python types.
+
 ## [0.2.0] - 2021-11-24
 ### Added
 - Added `message_field_name` parameter.
@@ -18,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Public release.
 
-[Unreleased]: https://github.com/Colin-b/healthpy/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/Colin-b/healthpy/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/Colin-b/healthpy/compare/v0.0.1...v0.1.0
-[0.0.1]: https://github.com/Colin-b/healthpy/releases/tag/v0.0.1
+[Unreleased]: https://github.com/Colin-b/logging_json/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/Colin-b/logging_json/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/Colin-b/logging_json/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/Colin-b/logging_json/compare/v0.0.1...v0.1.0
+[0.0.1]: https://github.com/Colin-b/logging_json/releases/tag/v0.0.1

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Colin Bounouar
+Copyright (c) 2022 Colin Bounouar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/logging_json/actions"><img alt="Build status" src="https://github.com/Colin-b/logging_json/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/logging_json/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/logging_json/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-17 passed-blue"></a>
+<a href="https://github.com/Colin-b/logging_json/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-18 passed-blue"></a>
 <a href="https://pypi.org/project/logging_json/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/logging_json"></a>
 </p>
 
@@ -35,7 +35,7 @@ It must be a dictionary where keys are the keys to be appended to the resulting 
 
 If an exception is logged, the `exception` key will be appended to the resulting JSON dictionary.
 
-This dictionary will contains 3 keys:
+This dictionary will contain 3 keys:
 * `type`: The name of the exception class (useful when the message is blank).
 * `message`: The str representation of the exception (usually the provided error message).
 * `stack`: The stack trace, formatted as a string.

--- a/logging_json/_formatter.py
+++ b/logging_json/_formatter.py
@@ -1,4 +1,5 @@
 import collections
+import datetime
 import json
 import logging
 from typing import Any, Dict
@@ -48,6 +49,12 @@ def _value(record: logging.LogRecord, field_name_or_value: Any) -> Any:
         return field_name_or_value
 
 
+def default_converter(obj: Any) -> str:
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    return str(obj)
+
+
 class JSONFormatter(logging.Formatter):
     def __init__(
         self,
@@ -84,11 +91,10 @@ class JSONFormatter(logging.Formatter):
                 "stack": self.formatException(record.exc_info),
             }
 
-        return (
-            super().formatMessage(record)
-            if (len(message) == 1 and self.message_field_name in message)
-            else json.dumps(message)
-        )
+        if len(message) == 1 and self.message_field_name in message:
+            return super().formatMessage(record)
+
+        return json.dumps(message, default=default_converter)
 
     def formatMessage(self, record: logging.LogRecord) -> str:
         # Speed up this step by doing nothing

--- a/logging_json/version.py
+++ b/logging_json/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
### Fixed
- `datetime`, `time` and `date` instances are now represented following [ISO-8601](https://www.iso.org/iso-8601-date-and-time-format.html) format instead of raising a `TypeError`.
- Default to the `str` representation of value instead of raising a `TypeError` for non-standard python types.
