### PR TITLE
Add exception_field parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ This dictionary will contain 3 keys:
 * `message`: The str representation of the exception (usually the provided error message).
 * `stack`: The stack trace, formatted as a string.
 
+You can rename the exception field key by setting the `exception_field_name` parameter with a new name for the key.
+It is also possible to disable this behaviour by setting the `exception_field_name` parameter to `None` or an empty string
+
 ### Logging with a dictionary
 
 This formatter allows you to log dictionary as in the following:
@@ -57,7 +60,7 @@ The resulting JSON dictionary will be the one you provided (with the [additional
 Anything not logged using a dictionary will be handled by the standard formatter and it can result in one of the 2 output:
 * A JSON dictionary, if [additional fields](#adding-additional-fields-and-values) are set or if `extra` parameter is used while logging, with the message available in the `msg` key of the resulting JSON dictionary.
   Default `msg` key name can be changed by `message_field_name` parameter of the `logging_json.JSONFormatter` instance.
-* The formatted record, if no [additional fields](#adding-additional-fields-and-values) are set. 
+* The formatted record, if no [additional fields](#adding-additional-fields-and-values) are set.
 
 This handles the usual string logging as in the following:
 

--- a/logging_json/_formatter.py
+++ b/logging_json/_formatter.py
@@ -2,7 +2,7 @@ import collections
 import datetime
 import json
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 standard_attributes = (
     "name",
@@ -61,6 +61,7 @@ class JSONFormatter(logging.Formatter):
         *args,
         fields: Dict[str, Any] = None,
         message_field_name: str = "msg",
+        exception_field_name: Optional[str] = "exception",
         **kwargs,
     ):
         # Allow to provide any formatter setting (useful to provide a custom date format)
@@ -68,6 +69,7 @@ class JSONFormatter(logging.Formatter):
         self.fields = fields or {}
         self.usesTime = lambda: "asctime" in self.fields.values()
         self.message_field_name = message_field_name
+        self.exception_field_name = exception_field_name
 
     def format(self, record: logging.LogRecord):
         # Let python set every additional record field
@@ -84,8 +86,8 @@ class JSONFormatter(logging.Formatter):
 
         message.update(_extra_attributes(record))
 
-        if record.exc_info:
-            message["exception"] = {
+        if self.exception_field_name and record.exc_info:
+            message[self.exception_field_name] = {
                 "type": record.exc_info[0].__name__,
                 "message": str(record.exc_info[1]),
                 "stack": self.formatException(record.exc_info),

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -2,6 +2,7 @@ import logging
 import json
 import time
 import datetime
+import pytest
 
 import logging_json
 
@@ -111,6 +112,38 @@ def test_dict_message_at_exception_level(caplog):
             "message": "this is the exception message",
             "type": "MyException",
         },
+    }
+
+
+def test_dict_message_at_exception_level_with_different_field_name(caplog):
+    caplog.set_level("INFO")
+    try:
+        raise MyException("this is the exception message")
+    except MyException:
+        logging.exception({"key 1": "value 1", "key 2": 2})
+    actual = dict_fmt(caplog, exception_field_name="info_about_exception")
+    actual["info_about_exception"].pop("stack")
+    assert actual == {
+        "key 1": "value 1",
+        "key 2": 2,
+        "info_about_exception": {
+            "message": "this is the exception message",
+            "type": "MyException",
+        },
+    }
+
+
+@pytest.mark.parametrize("value", [None, ""])
+def test_dict_message_at_exception_level_without_exception_field(caplog, value):
+    caplog.set_level("INFO")
+    try:
+        raise MyException("this is the exception message")
+    except MyException:
+        logging.exception({"key 1": "value 1", "key 2": 2})
+    actual = dict_fmt(caplog, exception_field_name=value)
+    assert actual == {
+        "key 1": "value 1",
+        "key 2": 2,
     }
 
 


### PR DESCRIPTION
Hello! We like to use your module in our application but we need to reuse exception field for our own purposes.
I think we have 2 ways:
- do not set exception field if already exists
- or add exception_field parameter which disables exception field

I have done second way. Can your review it please?