### PR TITLE
Release 0.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2023-01-09
+### Changed
+- Default message key is now `message` instead of `msg` to stay in line with python default. If you still want previous behavior, set `message_field_name` to `msg` at formatter creation.
+
 ## [0.3.0] - 2022-12-02
 ### Added
 - Added `exception_field_name` parameter.
@@ -27,7 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Public release.
 
-[Unreleased]: https://github.com/Colin-b/logging_json/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/Colin-b/logging_json/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/Colin-b/logging_json/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Colin-b/logging_json/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/Colin-b/logging_json/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Colin-b/logging_json/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Default message key is now `message` instead of `msg` to stay in line with python default. If you still want previous behavior, set `message_field_name` to `msg` at formatter creation.
 
+### Removed
+- Drop support for python 3.6.
+
 ## [0.3.0] - 2022-12-02
 ### Added
 - Added `exception_field_name` parameter.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Colin Bounouar
+Copyright (c) 2023 Colin Bounouar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ root:
 ```
 
 ## How to install
-1. [python 3.6+](https://www.python.org/downloads/) must be installed
+1. [python 3.7+](https://www.python.org/downloads/) must be installed
 2. Use pip to install module:
 ```sh
 python -m pip install logging_json

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/logging_json/actions"><img alt="Build status" src="https://github.com/Colin-b/logging_json/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/logging_json/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/logging_json/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-18 passed-blue"></a>
+<a href="https://github.com/Colin-b/logging_json/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-21 passed-blue"></a>
 <a href="https://pypi.org/project/logging_json/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/logging_json"></a>
 </p>
 
@@ -57,9 +57,9 @@ The resulting JSON dictionary will be the one you provided (with the [additional
 
 ### Logging with anything else (such as a string)
 
-Anything not logged using a dictionary will be handled by the standard formatter and it can result in one of the 2 output:
-* A JSON dictionary, if [additional fields](#adding-additional-fields-and-values) are set or if `extra` parameter is used while logging, with the message available in the `msg` key of the resulting JSON dictionary.
-  Default `msg` key name can be changed by `message_field_name` parameter of the `logging_json.JSONFormatter` instance.
+Anything not logged using a dictionary will be handled by the standard formatter, and it can result in one of the 2 output:
+* A JSON dictionary, if [additional fields](#adding-additional-fields-and-values) are set or if `extra` parameter is used while logging, with the message available in the `message` key of the resulting JSON dictionary.
+  Default `message` key name can be changed by `message_field_name` parameter of the `logging_json.JSONFormatter` instance.
 * The formatted record, if no [additional fields](#adding-additional-fields-and-values) are set.
 
 This handles the usual string logging as in the following:
@@ -72,7 +72,7 @@ logging.info("This is my message")
 
 ## Configuration
 
-You can create a formatter instance yourself as in the following or you can use a logging configuration.
+You can create a formatter instance yourself as in the following, or you can use a logging configuration.
 
 ```python
 import logging_json

--- a/logging_json/_formatter.py
+++ b/logging_json/_formatter.py
@@ -60,7 +60,7 @@ class JSONFormatter(logging.Formatter):
         self,
         *args,
         fields: Dict[str, Any] = None,
-        message_field_name: str = "msg",
+        message_field_name: str = "message",
         exception_field_name: Optional[str] = "exception",
         **kwargs,
     ):

--- a/logging_json/version.py
+++ b/logging_json/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Build Tools",
     ],
     keywords=["logging", "json"],
@@ -38,7 +39,7 @@ setup(
     extras_require={
         "testing": [
             # Used to check coverage
-            "pytest-cov==3.*",
+            "pytest-cov==4.*",
         ]
     },
     python_requires=">=3.6",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         "Natural Language :: English",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -42,7 +41,7 @@ setup(
             "pytest-cov==4.*",
         ]
     },
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     project_urls={
         "GitHub": "https://github.com/Colin-b/logging_json",
         "Changelog": "https://github.com/Colin-b/logging_json/blob/master/CHANGELOG.md",

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -39,27 +39,27 @@ def test_str_with_args_message(caplog):
 def test_str_with_message_field_name(caplog):
     caplog.set_level("INFO")
     logging.info("message 1")
-    assert fmt(caplog, message_field_name="message") == "message 1"
+    assert fmt(caplog, message_field_name="msg") == "message 1"
 
 
 def test_str_with_extra_message(caplog):
     caplog.set_level("INFO")
     logging.info("message 1", extra={"key1": "value 1"})
-    assert dict_fmt(caplog) == {"msg": "message 1", "key1": "value 1"}
+    assert dict_fmt(caplog) == {"message": "message 1", "key1": "value 1"}
 
 
 def test_str_with_message_field_name_and_fields(caplog):
     caplog.set_level("INFO")
     logging.info("message 1")
     assert dict_fmt(
-        caplog, message_field_name="message", fields={"level": "levelname"}
-    ) == {"message": "message 1", "level": "INFO"}
+        caplog, message_field_name="msg", fields={"level": "levelname"}
+    ) == {"msg": "message 1", "level": "INFO"}
 
 
 def test_str_with_args_and_extra_message(caplog):
     caplog.set_level("INFO")
     logging.info("message %s", "1", extra={"key1": "value 1"})
-    assert dict_fmt(caplog) == {"msg": "message 1", "key1": "value 1"}
+    assert dict_fmt(caplog) == {"message": "message 1", "key1": "value 1"}
 
 
 def test_dict_message_with_asctime(caplog, monkeypatch):
@@ -77,7 +77,7 @@ def test_str_message_with_asctime(caplog, monkeypatch):
     logging.info("message 1")
     actual = dict_fmt(caplog, fields={"date_time": "asctime"})
     assert time.strptime(actual.pop("date_time"), "%Y-%m-%d %H:%M:%S,007")
-    assert actual == {"msg": "message 1"}
+    assert actual == {"message": "message 1"}
 
 
 def test_str_with_args_message_with_asctime(caplog, monkeypatch):
@@ -86,7 +86,7 @@ def test_str_with_args_message_with_asctime(caplog, monkeypatch):
     logging.info("message %s", "1")
     actual = dict_fmt(caplog, fields={"date_time": "asctime"})
     assert time.strptime(actual.pop("date_time"), "%Y-%m-%d %H:%M:%S,007")
-    assert actual == {"msg": "message 1"}
+    assert actual == {"message": "message 1"}
 
 
 def test_str_with_args_and_extra_message_with_asctime(caplog, monkeypatch):
@@ -95,7 +95,7 @@ def test_str_with_args_and_extra_message_with_asctime(caplog, monkeypatch):
     logging.info("message %s", "1", extra={"key1": "value 1"})
     actual = dict_fmt(caplog, fields={"date_time": "asctime"})
     assert time.strptime(actual.pop("date_time"), "%Y-%m-%d %H:%M:%S,007")
-    assert actual == {"msg": "message 1", "key1": "value 1"}
+    assert actual == {"message": "message 1", "key1": "value 1"}
 
 
 def test_dict_message_at_exception_level(caplog):
@@ -157,7 +157,7 @@ def test_str_message_at_exception_level(caplog):
     actual = dict_fmt(caplog)
     actual["exception"].pop("stack")
     assert actual == {
-        "msg": "message 1",
+        "message": "message 1",
         "exception": {
             "message": "this is the exception message",
             "type": "MyException",
@@ -174,7 +174,7 @@ def test_str_with_args_message_at_exception_level(caplog):
     actual = dict_fmt(caplog)
     actual["exception"].pop("stack")
     assert actual == {
-        "msg": "message 1",
+        "message": "message 1",
         "exception": {
             "message": "this is the exception message",
             "type": "MyException",
@@ -237,7 +237,7 @@ def test_with_extra_in_fields_and_message(caplog):
         "extra": "value 1",
         "key1": "value 1",
         "key2": "value 2",
-        "msg": "message 1",
+        "message": "message 1",
     }
 
 


### PR DESCRIPTION
### Changed
- Default message key is now `message` instead of `msg` to stay in line with python default. If you still want previous behavior, set `message_field_name` to `msg` at formatter creation.

### Removed
- Drop support for python 3.6.
