### PR TITLE
Release 0.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,13 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.13'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 25.1.0
     hooks:
       - id: black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Using [`logging.exception`](https://docs.python.org/3/library/logging.html#logging.exception) outside an exception context will not prevent log from being formatted anymore.
 
+### Removed
+- Drop support for python `3.7`.
+
+### Added
+- Explicit support for python `3.13`.
+
 ## [0.5.0] - 2024-01-17
 ### Added
 - Explicit support for python `3.12`. Meaning `taskName` is now considered a reserved keyword where value is supposed to be contained in the record itself (otherwise value will be `taskName` for python < 3.12 when specified).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Drop support for python `3.7`.
+- Drop support for python `3.8`.
 
 ### Added
 - Explicit support for python `3.13`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.6.0] - 2025-02-04
 ### Fixed
 - Using [`logging.exception`](https://docs.python.org/3/library/logging.html#logging.exception) outside an exception context will not prevent log from being formatted anymore.
 
@@ -51,7 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Public release.
 
-[Unreleased]: https://github.com/Colin-b/logging_json/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/Colin-b/logging_json/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/Colin-b/logging_json/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Colin-b/logging_json/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Colin-b/logging_json/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Colin-b/logging_json/compare/v0.2.1...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Using [`logging.exception`](https://docs.python.org/3/library/logging.html#logging.exception) outside an exception context will not prevent log from being formatted anymore.
 
 ## [0.5.0] - 2024-01-17
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Colin Bounouar
+Copyright (c) 2025 Colin Bounouar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/logging_json/actions"><img alt="Build status" src="https://github.com/Colin-b/logging_json/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/logging_json/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/logging_json/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-25 passed-blue"></a>
+<a href="https://github.com/Colin-b/logging_json/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-27 passed-blue"></a>
 <a href="https://pypi.org/project/logging_json/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/logging_json"></a>
 </p>
 
@@ -33,7 +33,7 @@ It must be a dictionary where keys are the keys to be appended to the resulting 
 
 #### Logging exceptions, a specific case
 
-If an exception is logged, the `exception` key will be appended to the resulting JSON dictionary.
+If [an exception is logged](https://docs.python.org/3/library/logging.html#logging.exception), the `exception` key will be appended to the resulting JSON dictionary.
 
 This dictionary will contain 3 keys:
 * `type`: The name of the exception class (useful when the message is blank).

--- a/logging_json/_formatter.py
+++ b/logging_json/_formatter.py
@@ -56,6 +56,10 @@ def default_converter(obj: Any) -> str:
     return str(obj)
 
 
+def has_exception_info(record: logging.LogRecord) -> bool:
+    return record.exc_info and record.exc_info[0] is not None
+
+
 class JSONFormatter(logging.Formatter):
     def __init__(
         self,
@@ -92,7 +96,7 @@ class JSONFormatter(logging.Formatter):
 
         message.update(_extra_attributes(record))
 
-        if self.exception_field_name and record.exc_info:
+        if self.exception_field_name and has_exception_info(record):
             message[self.exception_field_name] = {
                 "type": record.exc_info[0].__name__,
                 "message": str(record.exc_info[1]),

--- a/logging_json/version.py
+++ b/logging_json/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "logging_json"
 description = "JSON formatter for python logging"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 authors = [
     {name = "Colin Bounouar", email = "colin.bounouar.dev@gmail.com" }
@@ -23,12 +23,12 @@ classifiers=[
     "Typing :: Typed",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Build Tools",
 ]
 dependencies = []
@@ -45,7 +45,7 @@ testing = [
     # Used to freeze time
     "time-machine==2.*",
     # Used to check coverage
-    "pytest-cov==4.*",
+    "pytest-cov==6.*",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "logging_json"
 description = "JSON formatter for python logging"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 authors = [
     {name = "Colin Bounouar", email = "colin.bounouar.dev@gmail.com" }
@@ -23,7 +23,6 @@ classifiers=[
     "Typing :: Typed",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -306,6 +306,25 @@ def test_json_dumps_error(caplog):
     }
 
 
+def test_exception_logging_without_exception_info(caplog):
+    caplog.set_level("INFO")
+    logging.exception("There is no exception context")
+
+    assert fmt(caplog) == "There is no exception context"
+
+
+def test_exception_logging_in_finally(caplog):
+    caplog.set_level("INFO")
+    try:
+        raise MyException("this is the exception message")
+    except MyException:
+        pass
+    finally:
+        logging.exception("Something happened")
+
+    assert fmt(caplog) == "Something happened"
+
+
 def fmt(caplog, *formatter_args, **formatter_kwargs) -> str:
     return logging_json.JSONFormatter(*formatter_args, **formatter_kwargs).format(
         caplog.records[0]


### PR DESCRIPTION
### Fixed
- Using [`logging.exception`](https://docs.python.org/3/library/logging.html#logging.exception) outside an exception context will not prevent log from being formatted anymore.

### Removed
- Drop support for python `3.7`.
- Drop support for python `3.8`.

### Added
- Explicit support for python `3.13`.